### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Robert Schnuell
 maintainer=Robert Schnuell <mail@robertschnuell.de>
 sentence=Arduino library for fading between different Colors
 paragraph=Arduino library for fading between different Colors
-category=LED
+category=Device Control
 url=https://github.com/robertschnuell/RGBFade
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'LED' in library RGBFade is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format